### PR TITLE
fix recordings link

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -30,7 +30,7 @@
             <a class="link" href="https://engelsystem.de/36c3/login" target="_blank" rel="noopener noreferrer">Engelsystem</a>
             <a class="link" href="https://guru3.eventphone.de/event.tcl/phonebook" target="_blank" rel="noopener noreferrer">Phonebook (guru)</a>
             <a class="link" href="https://streaming.media.ccc.de/36c3" target="_blank" rel="noopener noreferrer">Streaming</a>
-            <a class="link" href="https://media.ccc.de/c/35c3" target="_blank" rel="noopener noreferrer">Recordings</a>
+            <a class="link" href="https://media.ccc.de/c/36c3" target="_blank" rel="noopener noreferrer">Recordings</a>
             <a class="link" href="https://36c3.bleeptrack.de/" target="_blank" rel="noopener noreferrer">36c3 Generator</a>
             <a class="link link--thin" href="mailto:36c3@chaostreff-flensburg.de?subject=36c3.info suggestions">Suggestions? Mail us!</a>
             <a class="link link--thin" href="https://chaostreff-flensburg.de/impressum/">Impressum</a>


### PR DESCRIPTION
The recordings link pointed to the 35c3 recordings, this pr replaces it with the link to the 36c3 recordings. 